### PR TITLE
mkosi.build: simply ltp handling

### DIFF
--- a/mkosi.build
+++ b/mkosi.build
@@ -12,7 +12,10 @@ fi
 
 if [ -f "$SRCDIR/ltp/Makefile" ]; then
     cd "$SRCDIR/ltp"
-    ./build.sh
+    make -j "$(nproc)" autotools
+    ./configure
+    make -j "$(nproc)"
+    make install
 fi
 
 if [ -f "$SRCDIR/btrfs-progs/autogen.sh" ]; then


### PR DESCRIPTION
The ./build.sh script runs all kinds of tests during build causing unnecessary increase in image build time. Plus, we need to install ltp for it to be usable.