### PR TITLE
Fix location of vmlinux file

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ where all the files are, in order for things to work properly.
 
 ```
 $ gdb
-(gdb) file ~/source/mkosi-kernel/mkosi.output/image.vmlinux
+(gdb) file ~/source/mkosi-kernel/mkosi.builddir/<distro-release-arch>/kernel/<localversion>/image.vmlinux
 (gdb) set substitute-path /work/src/kernel ~/source/linux
 (gdb) target remote localhost:1234
 ```


### PR DESCRIPTION
When using incremental builds the vmlinux file is never copied into the output directory so we should instead use the file under the build directory.