### PR TITLE
Add clangd wrapper script 

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+CompileFlags:
+  Add: -Wno-unknown-warning-option
+  Remove: [--hack*, --ibt,--orc,--retpoline,--rethunk,--sls,--static-call,--uaccess,--link,--module,-mpreferred-stack*,-mindirect-branch*,-fno-allow-store*,-fconserve-stack,-mrecord-mcount,-ftrivial-auto*,-fmin-function-alignment=16]

--- a/mkosi.clangd
+++ b/mkosi.clangd
@@ -1,0 +1,52 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+set -eux
+
+PROFILE="$1"
+shift
+
+if [[ -n "${MKOSI_CONFIG-}" ]]; then
+    exec mkosi-chroot env --chdir="$SRCDIR/$PROFILE" clangd "$@"
+fi
+
+# If there's a mkosi.conf or mkosi.local.conf in the current working
+# directory, assume that Include=mkosi-kernel is used to include the
+# mkosi-kernel mkosi configuration. Otherwise, assume the user is
+# running mkosi directly from the mkosi-kernel repository.
+if [[ -f mkosi.conf ]] || [[ -f mkosi.local.conf ]]; then
+    DIRECTORY=()
+else
+    DIRECTORY=(--directory "$(dirname "$(realpath "$0")")")
+fi
+
+MKOSI_CONFIG="$(mkosi "${DIRECTORY[@]}" --json summary | jq -r .Images[-1])"
+
+DISTRIBUTION="$(jq -r .Distribution <<< "$MKOSI_CONFIG")"
+RELEASE="$(jq -r .Release <<< "$MKOSI_CONFIG")"
+ARCH="$(jq -r .Architecture <<< "$MKOSI_CONFIG")"
+
+BUILDDIR="$(jq -r .BuildDirectory <<< "$MKOSI_CONFIG")"
+CACHEDIR="$(jq -r .CacheDirectory <<< "$MKOSI_CONFIG")"
+
+BUILD_SOURCE_MAPPINGS="$(jq -r '[
+    .BuildSources[]
+    | .Source + "/='/work/src'/" + .Target
+] | join(",")' <<< "$MKOSI_CONFIG")"
+
+exec mkosi \
+    "${DIRECTORY[@]}" \
+    --incremental=strict \
+    --build-sources-ephemeral=no \
+    --format=none \
+    --build-script= \
+    --build-script="$(realpath "$0")" \
+    build \
+    "$PROFILE" \
+    --enable-config \
+    --compile-commands-dir=/work/build/"$PROFILE" \
+    --path-mappings="\
+$BUILD_SOURCE_MAPPINGS,\
+$BUILDDIR=/work/build,\
+$CACHEDIR/$DISTRIBUTION~$RELEASE~$ARCH.cache/usr/include/=/usr/include" \
+    "$@"

--- a/mkosi.conf.d/30-centos-fedora/mkosi.conf
+++ b/mkosi.conf.d/30-centos-fedora/mkosi.conf
@@ -8,6 +8,7 @@ Distribution=|fedora
 Packages=
         bpftool
         bpftrace
+        clang-tools-extra
         dnf
         drgn
         fio-engine-libaio

--- a/mkosi.profiles/bpfilter/mkosi.conf.d/20-centos-fedora.conf
+++ b/mkosi.profiles/bpfilter/mkosi.conf.d/20-centos-fedora.conf
@@ -6,7 +6,6 @@ Distribution=|fedora
 
 [Content]
 Packages=
-        clang-tools-extra
         ninja-build
         pkgconfig(cmocka)
         pkgconfig(libbpf)

--- a/mkosi.profiles/kernel/mkosi.build.chroot
+++ b/mkosi.profiles/kernel/mkosi.build.chroot
@@ -64,7 +64,7 @@ if [ -x /sbin/installkernel ]; then
     mount --bind /dev/null /sbin/installkernel
 fi
 
-EXTRA="O=$BUILDDIR V=1"
+EXTRA="O=$BUILDDIR"
 
 if ((LLVM)); then
     EXTRA="$EXTRA LLVM=1"

--- a/mkosi.profiles/kernel/mkosi.build.chroot
+++ b/mkosi.profiles/kernel/mkosi.build.chroot
@@ -87,6 +87,11 @@ export KBUILD_BUILD_USER="mkosi"
 
 make $EXTRA -j "$(nproc)" $( ((INCREMENTAL)) && echo modules)
 
+if ! ((INCREMENTAL)); then
+    echo "Generating compile-commands database"
+    scripts/clang-tools/gen_compile_commands.py -d "$BUILDDIR" -o "$BUILDDIR"/compile_commands.json
+fi
+
 # FIXME: Re-enable when coreutils 9.5 gets into debian testing.
 . /usr/lib/os-release
 if ! ((INCREMENTAL)) && [ ! "$ID" = "debian" ]; then


### PR DESCRIPTION
To make use of this to hack on Linux with vscode, add the following
to .vscode/settings.json in your Linux git checkout:

```json
{
    "clangd.path": "<path-to-mkosi-kernel>/mkosi.clangd",
    "clangd.arguments": ["kernel"],
}
```