### PR TITLE
Clean up jq filter for build source mappings

### DIFF
--- a/mkosi.clangd
+++ b/mkosi.clangd
@@ -33,12 +33,13 @@ shift # shift away profile
 HOST_BUILDDIR="$(jq -r .BuildDirectory "$MKOSI_CONFIG")"
 HOST_BUILDSUBDIR="$(jq -r .BuildSubdirectory "$MKOSI_CONFIG")"
 
-BUILD_SOURCE_MAPPINGS="$(jq -r '[
+BUILD_SOURCE_MAPPINGS="$(jq -r '
     .BuildSources
     | sort_by(.Target)
-    | reverse.[]
-    | .Source + "/=/work/src/" + .Target
-] | join(",")' "$MKOSI_CONFIG")"
+    | reverse
+    | map(.Source + "=/work/src/" + .Target)
+    | join(",")
+' "$MKOSI_CONFIG")"
 
 exec mkosi-chroot env --chdir="$SRCDIR/$PROFILE" clangd \
     --enable-config \


### PR DESCRIPTION
We can avoid converting the array to a stream and collecting it later by replacing the string operation with a simple map() call.