### PR TITLE
profiles: add cxl profile

### DIFF
--- a/mkosi.profiles/cxl/mkosi.conf
+++ b/mkosi.profiles/cxl/mkosi.conf
@@ -1,0 +1,9 @@
+[Runtime]
+MaxMem=8G
+CXL=true
+QemuArgs=
+	-object memory-backend-ram,id=vmem,size=1024M
+	-device pxb-cxl,bus_nr=12,bus=pcie.0,id=cxl.1
+	-device cxl-rp,port=0,bus=cxl.1,id=root_port13,chassis=0,slot=2
+	-device cxl-type3,bus=root_port13,volatile-memdev=vmem,id=cxl-vmem0
+	-M cxl-fmw.0.targets.0=cxl.1,cxl-fmw.0.size=1024M

--- a/mkosi.profiles/cxl/mkosi.extra/usr/lib/systemd/system-preset/00-cxl.preset
+++ b/mkosi.profiles/cxl/mkosi.extra/usr/lib/systemd/system-preset/00-cxl.preset
@@ -1,0 +1,1 @@
+enable cxl.service

--- a/mkosi.profiles/cxl/mkosi.extra/usr/lib/systemd/system/cxl.service
+++ b/mkosi.profiles/cxl/mkosi.extra/usr/lib/systemd/system/cxl.service
@@ -1,0 +1,7 @@
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c '/usr/sbin/cxl_probe.sh'
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/mkosi.profiles/cxl/mkosi.extra/usr/lib/tmpfiles.d/cxl.sh
+++ b/mkosi.profiles/cxl/mkosi.extra/usr/lib/tmpfiles.d/cxl.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Setup 1GB of CXL RAM
+echo ram > /sys/bus/cxl/devices/decoder2.0/mode
+echo 0x40000000 > /sys/bus/cxl/devices/decoder2.0/dpa_size
+echo region0 > /sys/bus/cxl/devices/decoder0.0/create_ram_region
+echo 256 > /sys/bus/cxl/devices/region0/interleave_granularity
+echo 1 > /sys/bus/cxl/devices/region0/interleave_ways
+echo 0x40000000 > /sys/bus/cxl/devices/region0/size
+echo decoder2.0 > /sys/bus/cxl/devices/region0/target0
+echo 1 > /sys/bus/cxl/devices/region0/commit
+echo region0 > /sys/bus/cxl/drivers/cxl_region/bind

--- a/mkosi.profiles/cxl/mkosi.extra/usr/sbin/cxl_probe.sh
+++ b/mkosi.profiles/cxl/mkosi.extra/usr/sbin/cxl_probe.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Setup 1GB of CXL RAM
+echo ram > /sys/bus/cxl/devices/decoder2.0/mode
+echo 0x40000000 > /sys/bus/cxl/devices/decoder2.0/dpa_size
+echo region0 > /sys/bus/cxl/devices/decoder0.0/create_ram_region
+echo 256 > /sys/bus/cxl/devices/region0/interleave_granularity
+echo 1 > /sys/bus/cxl/devices/region0/interleave_ways
+echo 0x40000000 > /sys/bus/cxl/devices/region0/size
+echo decoder2.0 > /sys/bus/cxl/devices/region0/target0
+echo 1 > /sys/bus/cxl/devices/region0/commit
+echo region0 > /sys/bus/cxl/drivers/cxl_region/bind


### PR DESCRIPTION
Adds mkosi.cxl, which adds a 1GB CXL memory expander to the QemuArgs and relevant runtime args for mkosi.
Also adds a simple probe service for system to automatically bring the memory up on boot.