### PR TITLE
debian: install libfuse3-dev instead of libfuse-dev

### DIFF
--- a/mkosi.profiles/kernel/mkosi.conf.d/20-debian.conf
+++ b/mkosi.profiles/kernel/mkosi.conf.d/20-debian.conf
@@ -13,7 +13,7 @@ Packages=
         libcap-ng-dev
         libcap-ng-utils
         libelf-dev
-        libfuse-dev
+        libfuse3-dev
         libmnl-dev
         libnftnl-dev
         libnuma-dev


### PR DESCRIPTION
The latter is deprecated and removed in testing now. The former is available in stable and oldstable so should be fine to use.