### PR TITLE
debian: replace isc-dhcp-client with dhcpcd

### DIFF
--- a/mkosi.conf.d/20-debian/mkosi.conf
+++ b/mkosi.conf.d/20-debian/mkosi.conf
@@ -15,13 +15,13 @@ Packages=
         clangd
         dbus-broker
         default-dbus-session-bus
+        dhcpcd
         gcc # Sanitizers
         git-core
         google-perftools
         hostname
         iproute2
         iputils-ping
-        isc-dhcp-client
         kmod
         libcap-ng-utils
         linux-perf


### PR DESCRIPTION
## Summary
- Replace `isc-dhcp-client` with `dhcpcd` in the Debian package list
- `isc-dhcp-client` has been removed from Debian trixie