### PR TITLE
debian: drop google-perftools

### DIFF
--- a/mkosi.conf.d/20-debian/mkosi.conf
+++ b/mkosi.conf.d/20-debian/mkosi.conf
@@ -18,7 +18,6 @@ Packages=
         dhcpcd
         gcc # Sanitizers
         git-core
-        google-perftools
         hostname
         iproute2
         iputils-ping


### PR DESCRIPTION
## Summary
- Remove `google-perftools` from the Debian package list as it is no longer needed