### PR TITLE
kernel: fix SELFTESTS_TARGETS word splitting in make invocations

### DIFF
--- a/mkosi.profiles/kernel/mkosi.build.chroot
+++ b/mkosi.profiles/kernel/mkosi.build.chroot
@@ -127,10 +127,10 @@ if ((SELFTESTS)); then
         SELFTESTS_SKIP_TARGETS=""
     fi
 
-    make -C tools/testing/selftests -j "$(nproc)" $EXTRA KSFT_INSTALL_PATH="$DESTDIR/usr/lib/kernel/selftests" $SELFTESTS_TARGETS $SELFTESTS_SKIP_TARGETS
+    make -C tools/testing/selftests -j "$(nproc)" $EXTRA KSFT_INSTALL_PATH="$DESTDIR/usr/lib/kernel/selftests" "$SELFTESTS_TARGETS" "$SELFTESTS_SKIP_TARGETS"
     if ! ((INCREMENTAL)); then
         mkdir -p "$DESTDIR/usr/lib/kernel/selftests"
-        make -C tools/testing/selftests -j "$(nproc)" $EXTRA KSFT_INSTALL_PATH="$DESTDIR/usr/lib/kernel/selftests" $SELFTESTS_TARGETS $SELFTESTS_SKIP_TARGETS install
+        make -C tools/testing/selftests -j "$(nproc)" $EXTRA KSFT_INSTALL_PATH="$DESTDIR/usr/lib/kernel/selftests" "$SELFTESTS_TARGETS" "$SELFTESTS_SKIP_TARGETS" install
         mkdir -p "$DESTDIR/usr/bin"
         ln -sf /usr/lib/kernel/selftests/bpf/bpftool "$DESTDIR/usr/bin/bpftool"
     fi


### PR DESCRIPTION
## Summary

`$SELFTESTS_TARGETS` and `$SELFTESTS_SKIP_TARGETS` are expanded unquoted in
the make command lines in `mkosi.profiles/kernel/mkosi.build.chroot`. After
the variable is reassigned to `TARGETS=mount mount_setattr fchmodat2 ...`,
word splitting causes make to see `TARGETS=mount` as the variable assignment
and the remaining target names as make goals rather than part of the TARGETS
value.

The result is that only the first selftest target is actually built and
installed; the rest are silently ignored.

Quote both variables so the entire `TARGETS=...` string is passed as a
single argument to make.