### PR TITLE
Fix more small nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ BuildSources=<path-to-your-btrfs-progs-sources>:btrfs-progs
 ```
 
 The same applies to the other profiles (`fstests`, `ltp`, `blktests`,
-`bpfilter`).
+`bpfilter`, `bpftrace`, `fio`, `cxl`).
 
 To enable multiple profiles, you can do the following:
 
@@ -90,7 +90,7 @@ the relevant `BuildSources=` entry without disabling the profile itself.
 This configuration will download the required tools to build and boot the image
 on the fly. To use this configuration, the following tools have to be installed:
 
-- mkosi v25
+- mkosi v26
 - python 3.9 (Set `$MKOSI_INTERPRETER` to point to an alternative interpreter)
 - package manager of the distribution you're building
 - coreutils

--- a/mkosi.profiles/cxl.conf
+++ b/mkosi.profiles/cxl.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 [Runtime]
 CXL=yes
 MaxMem=8G

--- a/mkosi.profiles/kernel/mkosi.conf.d/20-opensuse.conf
+++ b/mkosi.profiles/kernel/mkosi.conf.d/20-opensuse.conf
@@ -16,7 +16,6 @@ Packages=
         libcap-ng-utils
         libcap-progs
         libelf-devel
-        libelf-devel
         libmnl-devel
         libnuma-devel
         libopenssl-devel


### PR DESCRIPTION
## Summary

- Remove duplicate `libelf-devel` entry in openSUSE kernel profile
- Add missing SPDX license header to cxl profile
- Fix mkosi version requirement in README (v25 → v26) and add missing profiles (`bpftrace`, `fio`, `cxl`) to the profile list

## Test plan

- [ ] Verify openSUSE image builds without duplicate package warnings